### PR TITLE
Assign group to display.root_group...

### DIFF
--- a/code.py
+++ b/code.py
@@ -102,14 +102,14 @@ group.append(
         anchor_point=(0.5, 0.0),
     )
 )
-macropad.display.show(group)
+macropad.display.root_group = group
 
 # Load all the macro key setups from .py files in MACRO_FOLDER
 apps = []
 files = os.listdir(MACRO_FOLDER)
 files.sort()
 for filename in files:
-    if filename.endswith(".py"):
+    if filename.endswith(".py") and not filename.startswith("._"):
         try:
             module = __import__(MACRO_FOLDER + "/" + filename[:-3])
             apps.append(App(module.app))

--- a/code.py
+++ b/code.py
@@ -151,6 +151,7 @@ def lights_on():
     # triggers re-setting the neopixels
     macropad.pixels.brightness = 1
     apps[app_index].set_pixels()
+    macropad.pixels.show()
 
 
 def lights_off():


### PR DESCRIPTION

...since display.show(group) has been removed.

* Restored check to ignore “._” files to prevent a bunch of runtime warnings on Mac